### PR TITLE
Parse object literals, not just strict JSON

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -17,7 +17,10 @@ Parser.prototype.parseRequest = function(input, request) {
   request.hostname = input[0];
   request.method = input[1];
   if (input[2]) {
-    request.data = JSON.parse(input[2]);
+    request.data = (typeof input[2] === 'object' ?
+      input[2] :
+      JSON.parse(input[2])
+    );
   }
 
   return true;

--- a/test/arguments-parser-test.js
+++ b/test/arguments-parser-test.js
@@ -20,6 +20,13 @@ describe('parser', function() {
     expect(result.data.hello).to.eql('world');
   });
 
+  it('should parse object literals, not just strict json', function() {
+    var args = ['http://google.com', 'post', {hello: 'world'}];
+    var result = parser.parse(args);
+    expect(result.data).to.be.ok;
+    expect(result.data.hello).to.eql('world');
+  });
+
   it('should be able to get help', function() {
     var result = parser.parse(['-h']);
     expect(result['help']).to.be.true;


### PR DESCRIPTION
Oh sup @toastynerd!

I use this tool all the time, and I often forget that I need to format my requests as strict JSON--I'll try something like `superagent url verb {foo: 'bar'}`, not (the correct) `superagent url verb '{"foo": "bar"}'`. The former syntax is easier to read and write, too, with less room for human error. 

What if superagent-cli could parse _both_ options?

PR summary:
- Update Parser.prototype.parseRequest to handle either strict JSON or object literal syntax
- Add unit test to make sure it works (and doesn't break your other tests :)
