### PR TITLE
Can now use headers in a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ superagent-cli can read json data from a file using the -f parameter.
 ```
 superagent example.com/test post -f request_body.json
 ```
+superagent-cli can set arbitrary headers with -H
+```
+superagent -H "Accept: text/plain, X-Arbitrary-Header: true" example.com
+```

--- a/bin/superagent
+++ b/bin/superagent
@@ -19,6 +19,7 @@ if (request.help) {
   console.log('flags: ');
   console.log('-d, -v or --detail, --verbose display all information from response');
   console.log('-h or --help display this message');
+  console.log('-H or --headers include a string of request headers as "key: value[, key: value...]"')
   console.log('-u username:password for basic http authentication');
   console.log('-t milliseconds to set a specific timeout');
   console.log('-f <filename> to specify a file that contains the request body');

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,15 +1,15 @@
 var fs = require('fs');
 var vm = require('vm')
 
-var FLAGS = {'-d': 'detail', '--detail': 'detail', '-v': 'verbose', 
-              '--verbose': 'verbose'};
+var FLAGS = {'-d': 'detail', '--detail': 'detail', '-v': 'verbose',
+              '--verbose': 'verbose', '-H': 'headers', '--headers': 'headers'};
 
 var parseCmdObject = function(input) {
   var parsed;
   try {
     parsed = JSON.stringify(vm.runInThisContext('new Object(' + input.join('') + ')'));
   } catch(e) {
-    if (e.message === 'Unexpected identifier') 
+    if (e.message === 'Unexpected identifier')
       throw new Error("Error parsing object notation, remember to escape quotes on strings ex: {hello: \\\"world\\\"}");
     else
       throw e;
@@ -33,23 +33,23 @@ var Parser = function() {
 Parser.prototype.parseRequest = function(input, request) {
   request.hostname = input[0];
   request.method = input[1];
-  
+
   var data = ((input.length > 3) ? parseCmdObject(input.slice(2)) : input[2]);
   if (data) request.data = JSON.parse(data);
 
   return true;
 };
 
-/* 
+/*
  * Parser.prototype.parse
  * strip out flags before creating a request object
  */
-  
+
 Parser.prototype.parse = function(input) {
   var request = {};
   if (!input.length || input[0] === '-h' || input[0] === '--help') {
     request.help = true;
-    return request; 
+    return request;
   }
 
   /*
@@ -74,7 +74,29 @@ Parser.prototype.parse = function(input) {
     input.splice(timeoutIndex + 1);
     input.splice(timeoutIndex);
   }
-  
+
+  /*
+   * checking for headers in request
+   */
+  var headersIndex = input.indexOf('-H');
+  if (headersIndex >= 0) {
+    var headerString = input[headersIndex + 1];
+    function parseHeaderString(str) {
+      var headers = {};
+      str.split(',')
+        .map(function(a) { return a.replace(/\s*:\s+/, ': '); })
+        .map(function(a) { return a.trim(); })
+        .forEach(function(a) {
+          var key = a.split(': ')[0];
+          headers[key] = a.replace(key + ': ', '')
+        });
+      return headers;
+    }
+    request.headers = parseHeaderString(headerString);
+    input.splice(headersIndex + 1, 1);
+    input.splice(headersIndex, 1);
+  }
+
   /*
    * checking for a post body input file
    */
@@ -82,16 +104,16 @@ Parser.prototype.parse = function(input) {
   if (jsonFileIndex >= 0) {
     var filePath = input[jsonFileIndex + 1];
     var content = fs.readFileSync(filePath);
-    input.push(content.toString());    
+    input.push(content.toString());
     input.splice(jsonFileIndex + 1, 1);
     input.splice(jsonFileIndex, 1);
   }
-  
+
   input.forEach(function(flag, index, arr) {
     if (FLAGS[flag]) {
-      request[FLAGS[flag]] = true; 
+      request[FLAGS[flag]] = true;
       arr.splice(index, 1);
-    } 
+    }
   });
 
   if (input.length === 1) {
@@ -100,7 +122,7 @@ Parser.prototype.parse = function(input) {
 
   this.parseRequest(input, request);
   return request;
-}; 
+};
 
 var parser = new Parser();
 

--- a/lib/superagent-cli.js
+++ b/lib/superagent-cli.js
@@ -5,6 +5,9 @@ var sacli = function(input, callback) {
   if (input.user && input.password) {
     req.auth(input.user, input.password);
   }
+  if (input.headers) {
+    req.set(input.headers);
+  }
   req.send(input.data);
   req.timeout(input.timeout || 3000);
   req.end(callback);

--- a/test/arguments-parser-test.js
+++ b/test/arguments-parser-test.js
@@ -85,6 +85,23 @@ describe('parser', function() {
     expect(result['detail']).to.be.true;
   });
 
+  it('should be able to set a header in a request', function() {
+    var args = ['http://google.com', 'get', '-H', 'x-example-header: true'];
+    var result = parser.parse(args);
+    expect(typeof result.headers).to.eql('object');
+    expect(result.headers['x-example-header']).to.eql('true');
+    expect(result.headers['x-example-header']).to.not.eql(true);
+  });
+
+  it('should be able to set multiple headers in a request', function() {
+    var args = ['http://google.com', 'get', '-H', 'x-header-1: true, x-header-2: false'];
+    var result = parser.parse(args);
+    expect(result.headers['x-header-1']).to.eql('true');
+    expect(result.headers['x-header-1']).to.not.eql(true);
+    expect(result.headers['x-header-2']).to.eql('false');
+    expect(result.headers['x-header-2']).to.not.eql(false);
+  });
+
   after(function(done) {
     fs.unlink('test_file.json');
     done();

--- a/test/basic-rest-test.js
+++ b/test/basic-rest-test.js
@@ -13,7 +13,7 @@ describe('basic rest requests', function() {
     };
 
     superagentcli(request, function(err, res) {
-      expect(res.text).to.eql('get okay');  
+      expect(res.text).to.eql('get okay');
       done();
     });
   });
@@ -28,7 +28,7 @@ describe('basic rest requests', function() {
     superagentcli(request, function(err,res) {
       expect(res.body.msg).to.eql('post okay');
       done();
-    });	
+    });
   });
 
   it('should be able to make a put request', function(done) {
@@ -44,7 +44,7 @@ describe('basic rest requests', function() {
     });
   });
 
-  it('should be able to make a patch reques', function(done) {
+  it('should be able to make a patch request', function(done) {
     var request = {
       hostname: 'http://localhost:3000',
       method: 'patch',
@@ -67,5 +67,19 @@ describe('basic rest requests', function() {
       expect(res.text).to.eql('delete okay');
       done();
     });
+  });
+
+  it('should be able to make a request with headers', function(done) {
+    var request = {
+      hostname: 'http://localhost:3000/headers',
+      headers: {'x-test-header': 'true'},
+      method: 'get'
+    };
+
+    superagentcli(request, function(err, res) {
+      expect(res.body['x-test-header']).to.eql('true');
+      expect(res.body['x-test-header']).to.not.eql(true);
+      done();
+    })
   });
 });

--- a/test/testserver.js
+++ b/test/testserver.js
@@ -26,5 +26,9 @@ app.delete('/', function(req, res) {
   res.send('delete okay');
 });
 
+app.get('/headers', function(req, res) {
+  res.json(req.headers);
+});
+
 var server = http.createServer(app);
 server.listen(3000);


### PR DESCRIPTION
Functionality is added to the parser to parse out headers ("-H"/"--header") on the command line, and send them in the Ajax header. Unit tests are added as well.
